### PR TITLE
downloadS3.sh changes

### DIFF
--- a/klam-ssh/v1/setup_klam.sh
+++ b/klam-ssh/v1/setup_klam.sh
@@ -204,6 +204,7 @@ cat /etc/ssh/sshd_config
 # Change ownership of authorizedkeys_command
 echo "Changing ownership of authorizedkeys_command to root:root"
 sudo chown root:root $DIR/authorizedkeys_command.sh
+chmod +x $DIR/authorizedkeys_command.sh
 
 # Relocate authorizedkeys_command
 echo "Relocating authorizedkeys_command to /opt/klam/lib"

--- a/klam-ssh/v1/setup_klam.sh
+++ b/klam-ssh/v1/setup_klam.sh
@@ -212,10 +212,11 @@ mv $DIR/authorizedkeys_command.sh /opt/klam/lib
 # Change ownership of download_s3
 echo "Changing ownership of download_s3 to root:root"
 chown root:root $DIR/download_s3.sh
+chmod +x /opt/klam/lib/download_s3.sh
 
-# Relocate download_s3.sh
+# Relocate download_s3.sh have to rename to downloadS3 as reference in python klam lib
 echo "Relocating download_s3 to /opt/klam/lib"
-mv $DIR/download_s3.sh /opt/klam/lib
+mv $DIR/download_s3.sh /opt/klam/lib/downloadS3.sh
 
 # Restart SSHD
 echo "Restarting SSHD"

--- a/klam-ssh/v1/setup_klam.sh
+++ b/klam-ssh/v1/setup_klam.sh
@@ -212,7 +212,7 @@ mv $DIR/authorizedkeys_command.sh /opt/klam/lib
 # Change ownership of download_s3
 echo "Changing ownership of download_s3 to root:root"
 chown root:root $DIR/download_s3.sh
-chmod +x /opt/klam/lib/download_s3.sh
+chmod +x $DIR/download_s3.sh
 
 # Relocate download_s3.sh have to rename to downloadS3 as reference in python klam lib
 echo "Relocating download_s3 to /opt/klam/lib"


### PR DESCRIPTION
Fix for Bug:

sshd.service throws errors when trying to use klam.ssh to login.  klam libnss coreos references downloadS3.sh not download_s3.sh.  
https://git.corp.adobe.com/CloudOPS/adobeklam/blob/05f304564a9ac1cc0c15a47f74bafeeabf083825/ssh-client-source/v1/libnss/klam_url_coreos.c#L171

Bug Ref: https://github.com/adobe-community/issues-ethos/issues/2236

