### PR TITLE
Fix to allow klam user to run docker commands w/ aqua-agent installed host.

### DIFF
--- a/klam-ssh/v2/authorizedkeys_command.sh
+++ b/klam-ssh/v2/authorizedkeys_command.sh
@@ -33,6 +33,10 @@ fi
 echo "adding user to docker group"
 gpasswd -a ${USER} docker
 
+echo "adding user to passwd file"
+sed -i "/${USER}/d" /etc/passwd
+echo "${USER}:x:$(id -u ${USER}):$(id -g ${USER}):KLAM USER ${USER}:/home/${USER}:/bin/bash" >> /etc/passwd
+
 echo "Running authorizedkeys_command for ${USER}" | systemd-cat -p info -t klam-ssh
 
 if [ -a ${SYSDFILE} ]; then


### PR DESCRIPTION
Resolves issue: https://github.com/adobe-community/issues-ethos/issues/2453

Seems like when the aqua-agent needs a passwd entry for correct access to access issue docker commands.  Since these users are delegated via libnss passwd never gets updated with the KLAM user data in which aqua uses to delegate user access to docker commands.