### PR TITLE
Fix update_iptables.sh to also support non-AWS nodes

### DIFF
--- a/iam-role-iptables/v1/update_iptables.sh
+++ b/iam-role-iptables/v1/update_iptables.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-EXISTING=$(sudo iptables -t nat -L | grep instance-data.ec2.internal)
+EXISTING="$(sudo iptables -w -t nat -L | egrep 'instance-data|169.254.169.254')"
 
 # If existing is not empty, simply sleep
 if [[ ! -z $EXISTING ]]; then
@@ -11,10 +11,10 @@ fi
 echo $(date -u) "IPTABLES rule does not exist. Creating..."
 
 export NETWORK="bridge"
-export GATEWAY="$(ifconfig docker0 | grep "inet " | awk -F: '{print $1}' | awk '{print $2}')"
+export GATEWAY="$(ifconfig docker0 | grep 'inet ' | awk -F: '{print $1}' | awk '{print $2}')"
 export INTERFACE="docker0"
 
-sudo iptables -t nat -I PREROUTING -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination "$GATEWAY":8080 -i "$INTERFACE"
+sudo iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination "$GATEWAY":8080 -i "$INTERFACE"
 
 if [[ $? -eq 0 ]]; then
 	echo $(date -u) "IPTABLES rule created. Sleeping..."
@@ -23,7 +23,7 @@ else
 	while [ $? != 0 ]; do
 		sleep 5;
 		echo $(date -u) "IPTABLES rule creation failed. Retrying..."
-		sudo iptables -t nat -I PREROUTING -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination "$GATEWAY":8080 -i "$INTERFACE"
+		sudo iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination "$GATEWAY":8080 -i "$INTERFACE"
 	done
 fi
 


### PR DESCRIPTION
- Switching EXISTING check to egrep of instance-data or 169.254.169.254, to hopefully work in AWS and not
- Adding the "-w" iptables switch to wait for lock, as I was seeing frequent fails on start with lock errors which could prevent getting valid iptables results.  The potential risk is a long wait as the version on coreos currently doesn't support the optional seconds to wait option.  I don't expect this to be a problem.