### PR TITLE
Klam: changes for systemd installation compatibility.

### DIFF
--- a/klam-ssh/v2/authorizedkeys_command.sh
+++ b/klam-ssh/v2/authorizedkeys_command.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 USER=$1
 SYSDFILE="/etc/docker/daemon.json"

--- a/klam-ssh/v2/download_s3.sh
+++ b/klam-ssh/v2/download_s3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 USER=$1
 SYSDFILE="/etc/systemd/system/docker.service.d/*namespaces*.conf"
@@ -6,12 +6,12 @@ SYSDFILE="/etc/systemd/system/docker.service.d/*namespaces*.conf"
 # docker start functions
 start_nsdocker ()
 {
-  docker run --net=host --privileged --userns=host --rm -e ROLE_NAME=${ROLE_NAME} -e ENCRYPTION_ID=${ENCRYPTION_ID} -e ENCRYPTION_KEY=${ENCRYPTION_KEY} -e KEY_LOCATION_PREFIX=${KEY_LOCATION_PREFIX} ${IMAGE} /usr/lib/klam/downloadS3.py
+  docker run --net=host --privileged --userns=host --rm -e ROLE_NAME=${ROLE_NAME} -e ENCRYPTION_ID=${ENCRYPTION_ID} -e ENCRYPTION_KEY=${ENCRYPTION_KEY} -e KEY_LOCATION_PREFIX=${KEY_LOCATION_PREFIX} ${IMAGE} /usr/lib/klam/downloadS3/downloadS3
 }
 
 start_docker ()
 {
-  docker run --net=host --rm -e ROLE_NAME=${ROLE_NAME} -e ENCRYPTION_ID=${ENCRYPTION_ID} -e ENCRYPTION_KEY=${ENCRYPTION_KEY} -e KEY_LOCATION_PREFIX=${KEY_LOCATION_PREFIX} ${IMAGE} /usr/lib/klam/downloadS3.py
+  docker run --net=host --rm -e ROLE_NAME=${ROLE_NAME} -e ENCRYPTION_ID=${ENCRYPTION_ID} -e ENCRYPTION_KEY=${ENCRYPTION_KEY} -e KEY_LOCATION_PREFIX=${KEY_LOCATION_PREFIX} ${IMAGE} /usr/lib/klam/downloadS3/downloadS3
 }
 
 


### PR DESCRIPTION
1.  Bug Fix the systemd service from activating to activated state by adding new option added to bypass daemon loop.   
2. Removing log file permissions change in favor or grouping that to systemd hubble remediation change. This change will need to be grouped in with a hubble change in infrastructure.
3. Fix for downloadS3 script due to new images for klam installation validation.

Note:
This needs to be merged first and referenced by infrastructure PR https://git.corp.adobe.com/adobe-platform/dcos-infrastructure/pull/555.  Since this change alters some PENTest remediation tasks the universe change will be directly paired with a correlating infrastructure change as well. 