### PR TITLE
KLAM: userns for downloads3 script

### DIFF
--- a/klam-ssh/v2/download_s3.sh
+++ b/klam-ssh/v2/download_s3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 USER=$1
-SYSDFILE="/etc/systemd/system/docker.service.d/*namespaces*.conf"
+SYSDFILE="/etc/docker/daemon.json"
 
 # docker start functions
 start_nsdocker ()


### PR DESCRIPTION
Fix for systemd klam-ssh workers failing component healthcheck.
will need a SHA for infrastrucure PR:https://git.corp.adobe.com/adobe-platform/dcos-infrastructure/pull/555