### PR TITLE
Fluentd Configurations

### DIFF
--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-1.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-1.conf
@@ -1,0 +1,499 @@
+<source>
+  type monitor_agent
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_MONITOR_PORT']}"
+</source>
+
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_1']}"
+</source>
+
+<source>
+  @type systemd
+  @id ingest_from_journald
+  @label @mainstream
+  path "#{ENV['FLUENTD_SYSTEMD_PATH']}"
+  filters "#{ENV['FLUENTD_SYSTEMD_FILTERS']}"
+  pos_file "#{ENV['FLUENTD_SYSTEMD_POS_FILE']}"
+  read_from_head "#{ENV['FLUENTD_SYSTEMD_READ_FROM_HEAD']}"
+  strip_underscores "#{ENV['FLUENTD_SYSTEMD_STRIP_UNDERSCORES']}"
+  tag collector.systemlog
+</source>
+
+<source>
+  @type tail
+  @id ingest_from_tail
+  @label @mainstream
+  read_from_head "#{ENV['FLUENTD_TAIL_READ_FROM_HEAD']}"
+  refresh_interval "#{ENV['FLUENTD_TAIL_REFRESH_INTERVAL']}"
+  enable_watch_timer "#{ENV['FLUENTD_TAIL_ENABLE_WATCH_TIMER']}"
+  rotate_wait "#{ENV['FLUENTD_TAIL_ROTATE_WAIT']}"
+  path "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/**/std*"
+  exclude_path "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/**/std*.*"
+  pos_file "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/fluentd.pos"
+  path_key "#{ENV['FLUENTD_TAIL_PATH_KEY']}"
+  format none
+  tag collector.executorlog
+</source>
+
+<label @mainstream>
+
+  # Discard all log records that have an empty or missing message field
+  # Drop logs with blank lines
+  <filter collector.executorlog>
+    @type grep
+    @id blank_line_filter
+    regexp1 message \S+
+  </filter>
+  <filter collector.systemlog>
+    @type grep
+    @id blank_line_filter2
+    regexp1 MESSAGE \S+
+  </filter>
+
+  # Discard all executor logs except for those specific to the ETHOS cluster
+  <filter collector.executorlog>
+    @type grep
+    @id filter_mesos_executor_log
+    regexp1 file_path executors\/(agentfill|apigateway|aqua-agent|aqua-ethos-setup|aqua-gateway|aqua-web|booster|capcom|docker-cleanup|dsn|ecr-login|etcd|ethos-datadog|ethos-fluentd|ethos-splunkforwarder|feature-flipper-cache|flight-director|horizon|iam-role-iptables|iam-role-proxy|jenkins|klam-ssh|mercury|moonbeam|moonmaker|orca|prometheus|sidekick|skopos)
+  </filter>
+
+  # Set the timestamp and source_host field for local records
+  # and lop off the collector prefix on the tag
+  <match collector.**>
+    @type record_reformer
+    @id set_logging_host
+    tag ${tag_suffix[1]}
+    <record>
+      timestamp ${(Time.now.to_f).to_s}
+      source_host "#{ENV['MESOS_CLUSTER']},#{ENV['ethos_role']},#{ENV['zone']},#{ENV['HOST']}"
+    </record>
+  </match>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/1/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/1/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/1/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/1/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match splunkes.**>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunkes
+        server "#{ENV['FLUENTD_SPLUNKES_HEC_SERVER']}"
+        verify "#{ENV['FLUENTD_SPLUNKES_HEC_SSL_VERIFY']}"
+        token "#{ENV['FLUENTD_SPLUNKES_HEC_TOKEN']}"
+        time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+        all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+        post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+        post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+        protocol "#{ENV['FLUENTD_SPLUNKES_HEC_PROTOCOL']}"
+        batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+        coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+        non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/splunkes/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+        max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+        num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+        host ${record["host"]}
+        index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_INDEX']}"
+        source ${record["source"]}
+        sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_SOURCETYPE']}"
+        <secondary>
+          @type s3
+          s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+          s3_region us-east-1
+          path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+          s3_object_key_format "%{path}collector/1/splunkes/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+          store_as text
+          buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+          buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/splunkes/"
+          buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+          buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+          flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+          flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+          retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+          <assume_role_credentials>
+           role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+           role_session_name fluentd-s3
+          </assume_role_credentials>
+        </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemloges_metrics
+      @label @counts
+      tag fluentd.splunkes.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-2.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-2.conf
@@ -1,0 +1,433 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_2']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/2/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/2/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/2/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/2/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match splunkes.**>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunkes
+        server "#{ENV['FLUENTD_SPLUNKES_HEC_SERVER']}"
+        verify "#{ENV['FLUENTD_SPLUNKES_HEC_SSL_VERIFY']}"
+        token "#{ENV['FLUENTD_SPLUNKES_HEC_TOKEN']}"
+        time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+        all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+        post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+        post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+        protocol "#{ENV['FLUENTD_SPLUNKES_HEC_PROTOCOL']}"
+        batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+        coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+        non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/splunkes/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+        max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+        num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+        host ${record["host"]}
+        index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_INDEX']}"
+        source ${record["source"]}
+        sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_SOURCETYPE']}"
+        <secondary>
+          @type s3
+          s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+          s3_region us-east-1
+          path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+          s3_object_key_format "%{path}collector/2/splunkes/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+          store_as text
+          buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+          buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/splunkes/"
+          buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+          buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+          flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+          flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+          retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+          <assume_role_credentials>
+           role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+           role_session_name fluentd-s3
+          </assume_role_credentials>
+        </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemloges_metrics
+      @label @counts
+      tag fluentd.splunkes.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-3.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-3.conf
@@ -1,0 +1,433 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_3']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}    
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/3/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/3/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/3/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/3/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match splunkes.**>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunkes
+        server "#{ENV['FLUENTD_SPLUNKES_HEC_SERVER']}"
+        verify "#{ENV['FLUENTD_SPLUNKES_HEC_SSL_VERIFY']}"
+        token "#{ENV['FLUENTD_SPLUNKES_HEC_TOKEN']}"
+        time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+        all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+        post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+        post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+        protocol "#{ENV['FLUENTD_SPLUNKES_HEC_PROTOCOL']}"
+        batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+        coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+        non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/splunkes/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+        max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+        num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+        host ${record["host"]}
+        index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_INDEX']}"
+        source ${record["source"]}
+        sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_SOURCETYPE']}"
+        <secondary>
+          @type s3
+          s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+          s3_region us-east-1
+          path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+          s3_object_key_format "%{path}collector/3/splunkes/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+          store_as text
+          buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+          buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/splunkes/"
+          buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+          buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+          flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+          flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+          retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+          <assume_role_credentials>
+           role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+           role_session_name fluentd-s3
+          </assume_role_credentials>
+        </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemloges_metrics
+      @label @counts
+      tag fluentd.splunkes.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-4.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-4.conf
@@ -1,0 +1,433 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_4']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/4/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/4/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/4/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/4/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match splunkes.**>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunkes
+        server "#{ENV['FLUENTD_SPLUNKES_HEC_SERVER']}"
+        verify "#{ENV['FLUENTD_SPLUNKES_HEC_SSL_VERIFY']}"
+        token "#{ENV['FLUENTD_SPLUNKES_HEC_TOKEN']}"
+        time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+        all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+        post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+        post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+        protocol "#{ENV['FLUENTD_SPLUNKES_HEC_PROTOCOL']}"
+        batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+        coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+        non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/splunkes/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+        max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+        num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+        host ${record["host"]}
+        index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_INDEX']}"
+        source ${record["source"]}
+        sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_SOURCETYPE']}"
+        <secondary>
+          @type s3
+          s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+          s3_region us-east-1
+          path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+          s3_object_key_format "%{path}collector/4/splunkes/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+          store_as text
+          buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+          buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/splunkes/"
+          buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+          buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+          flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+          flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+          retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+          <assume_role_credentials>
+           role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+           role_session_name fluentd-s3
+          </assume_role_credentials>
+        </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemloges_metrics
+      @label @counts
+      tag fluentd.splunkes.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-5.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-5.conf
@@ -1,0 +1,433 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_5']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/5/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/5/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/5/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/5/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match splunkes.**>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunkes
+        server "#{ENV['FLUENTD_SPLUNKES_HEC_SERVER']}"
+        verify "#{ENV['FLUENTD_SPLUNKES_HEC_SSL_VERIFY']}"
+        token "#{ENV['FLUENTD_SPLUNKES_HEC_TOKEN']}"
+        time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+        all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+        post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+        post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+        protocol "#{ENV['FLUENTD_SPLUNKES_HEC_PROTOCOL']}"
+        batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+        coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+        non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/splunkes/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+        max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+        num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+        host ${record["host"]}
+        index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_INDEX']}"
+        source ${record["source"]}
+        sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_SOURCETYPE']}"
+        <secondary>
+          @type s3
+          s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+          s3_region us-east-1
+          path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+          s3_object_key_format "%{path}collector/5/splunkes/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+          store_as text
+          buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+          buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/splunkes/"
+          buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+          buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+          flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+          flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+          retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+          <assume_role_credentials>
+           role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+           role_session_name fluentd-s3
+          </assume_role_credentials>
+        </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemloges_metrics
+      @label @counts
+      tag fluentd.splunkes.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-6.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-6.conf
@@ -1,0 +1,433 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_6']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/6/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/6/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/6/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/6/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match splunkes.**>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunkes
+        server "#{ENV['FLUENTD_SPLUNKES_HEC_SERVER']}"
+        verify "#{ENV['FLUENTD_SPLUNKES_HEC_SSL_VERIFY']}"
+        token "#{ENV['FLUENTD_SPLUNKES_HEC_TOKEN']}"
+        time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+        all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+        post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+        post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+        protocol "#{ENV['FLUENTD_SPLUNKES_HEC_PROTOCOL']}"
+        batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+        coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+        non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/splunkes/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+        max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+        num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+        host ${record["host"]}
+        index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_INDEX']}"
+        source ${record["source"]}
+        sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_SOURCETYPE']}"
+        <secondary>
+          @type s3
+          s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+          s3_region us-east-1
+          path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+          s3_object_key_format "%{path}collector/6/splunkes/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+          store_as text
+          buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+          buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/splunkes/"
+          buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+          buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+          flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+          flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+          retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+          <assume_role_credentials>
+           role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+           role_session_name fluentd-s3
+          </assume_role_credentials>
+        </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemloges_metrics
+      @label @counts
+      tag fluentd.splunkes.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-7.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-7.conf
@@ -1,0 +1,433 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_7']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/7/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/7/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/7/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/7/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match splunkes.**>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunkes
+        server "#{ENV['FLUENTD_SPLUNKES_HEC_SERVER']}"
+        verify "#{ENV['FLUENTD_SPLUNKES_HEC_SSL_VERIFY']}"
+        token "#{ENV['FLUENTD_SPLUNKES_HEC_TOKEN']}"
+        time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+        all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+        post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+        post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+        protocol "#{ENV['FLUENTD_SPLUNKES_HEC_PROTOCOL']}"
+        batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+        coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+        non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/splunkes/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+        max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+        num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+        host ${record["host"]}
+        index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_INDEX']}"
+        source ${record["source"]}
+        sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_SOURCETYPE']}"
+        <secondary>
+          @type s3
+          s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+          s3_region us-east-1
+          path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+          s3_object_key_format "%{path}collector/7/splunkes/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+          store_as text
+          buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+          buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/splunkes/"
+          buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+          buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+          flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+          flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+          retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+          <assume_role_credentials>
+           role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+           role_session_name fluentd-s3
+          </assume_role_credentials>
+        </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemloges_metrics
+      @label @counts
+      tag fluentd.splunkes.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-8.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp-8.conf
@@ -1,0 +1,433 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_8']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/8/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/8/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/8/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/8/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+    <store>
+      @type rewrite_tag_filter
+      rewriterule1 message .+ splunkes.${tag}
+    </store>
+  </match>
+
+  <match splunkes.**>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunkes
+        server "#{ENV['FLUENTD_SPLUNKES_HEC_SERVER']}"
+        verify "#{ENV['FLUENTD_SPLUNKES_HEC_SSL_VERIFY']}"
+        token "#{ENV['FLUENTD_SPLUNKES_HEC_TOKEN']}"
+        time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+        all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+        post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+        post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+        protocol "#{ENV['FLUENTD_SPLUNKES_HEC_PROTOCOL']}"
+        batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+        coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+        non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/splunkes/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+        max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+        num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+        host ${record["host"]}
+        index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_INDEX']}"
+        source ${record["source"]}
+        sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNKES_SOURCETYPE']}"
+        <secondary>
+          @type s3
+          s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+          s3_region us-east-1
+          path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+          s3_object_key_format "%{path}collector/8/splunkes/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+          store_as text
+          buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+          buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/splunkes/"
+          buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+          buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+          flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+          flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+          retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+          <assume_role_credentials>
+           role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+           role_session_name fluentd-s3
+          </assume_role_credentials>
+        </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemloges_metrics
+      @label @counts
+      tag fluentd.splunkes.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-ccf-mp.conf
@@ -1,0 +1,47 @@
+<source>
+  @type multiprocess
+
+  # optional:
+  #graceful_kill_interval 2s
+  #graceful_kill_interval_increment 3s
+  #graceful_kill_timeout 60s
+
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-ccf-mp-1.conf
+    pid_file /var/run/fluentd_child1.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-ccf-mp-2.conf
+    sleep_before_start 5s
+    pid_file /var/run/fluentd_child2.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-ccf-mp-3.conf
+    sleep_before_shutdown 5s
+    pid_file /var/run/fluentd_child3.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-ccf-mp-4.conf
+    sleep_before_shutdown 5s
+    pid_file /var/run/fluentd_child4.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-ccf-mp-5.conf
+    pid_file /var/run/fluentd_child5.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-ccf-mp-6.conf
+    sleep_before_start 5s
+    pid_file /var/run/fluentd_child6.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-ccf-mp-7.conf
+    sleep_before_shutdown 5s
+    pid_file /var/run/fluentd_child7.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-ccf-mp-8.conf
+    sleep_before_shutdown 5s
+    pid_file /var/run/fluentd_child8.pid
+  </process>
+</source>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp-1.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp-1.conf
@@ -1,0 +1,427 @@
+<source>
+  type monitor_agent
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_MONITOR_PORT']}"
+</source>
+
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_1']}"
+</source>
+
+<source>
+  @type systemd
+  @id ingest_from_journald
+  @label @mainstream
+  path "#{ENV['FLUENTD_SYSTEMD_PATH']}"
+  filters "#{ENV['FLUENTD_SYSTEMD_FILTERS']}"
+  pos_file "#{ENV['FLUENTD_SYSTEMD_POS_FILE']}"
+  read_from_head "#{ENV['FLUENTD_SYSTEMD_READ_FROM_HEAD']}"
+  strip_underscores "#{ENV['FLUENTD_SYSTEMD_STRIP_UNDERSCORES']}"
+  tag collector.systemlog
+</source>
+
+<source>
+  @type tail
+  @id ingest_from_tail
+  @label @mainstream
+  read_from_head "#{ENV['FLUENTD_TAIL_READ_FROM_HEAD']}"
+  refresh_interval "#{ENV['FLUENTD_TAIL_REFRESH_INTERVAL']}"
+  enable_watch_timer "#{ENV['FLUENTD_TAIL_ENABLE_WATCH_TIMER']}"
+  rotate_wait "#{ENV['FLUENTD_TAIL_ROTATE_WAIT']}"
+  path "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/**/std*"
+  exclude_path "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/**/std*.*"
+  pos_file "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/fluentd.pos"
+  path_key "#{ENV['FLUENTD_TAIL_PATH_KEY']}"
+  format none
+  tag collector.executorlog
+</source>
+
+<label @mainstream>
+
+  # Discard all log records that have an empty or missing message field
+  # Drop logs with blank lines
+  <filter collector.executorlog>
+    @type grep
+    @id blank_line_filter
+    regexp1 message \S+
+  </filter>
+  <filter collector.systemlog>
+    @type grep
+    @id blank_line_filter2
+    regexp1 MESSAGE \S+
+  </filter>
+
+  # Discard all executor logs except for those specific to the ETHOS cluster
+  <filter collector.executorlog>
+    @type grep
+    @id filter_mesos_executor_log
+    regexp1 file_path executors\/(agentfill|apigateway|aqua-agent|aqua-ethos-setup|aqua-gateway|aqua-web|booster|capcom|docker-cleanup|dsn|ecr-login|etcd|ethos-datadog|ethos-fluentd|ethos-splunkforwarder|feature-flipper-cache|flight-director|jenkins|iam-role-iptables|iam-role-proxy|klam-ssh|mercury|moonbeam|moonmaker|orca|prometheus|sidekick|skopos)
+  </filter>
+
+  # Set the timestamp and source_host field for local records
+  # and lop off the collector prefix on the tag
+  <match collector.**>
+    @type record_reformer
+    @id set_logging_host
+    tag ${tag_suffix[1]}
+    <record>
+      timestamp ${(Time.now.to_f).to_s}
+      source_host "#{ENV['MESOS_CLUSTER']},#{ENV['ethos_role']},#{ENV['zone']},#{ENV['HOST']}"
+    </record>
+  </match>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/1/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/1/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/1/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/1/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/1/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp-2.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp-2.conf
@@ -1,0 +1,361 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_2']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/2/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/2/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/2/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/2/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/2/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp-3.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp-3.conf
@@ -1,0 +1,361 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_3']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/3/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/3/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/3/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/3/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/3/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp-4.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp-4.conf
@@ -1,0 +1,361 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_4']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/4/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/4/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/4/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/4/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/4/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp-5.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp-5.conf
@@ -1,0 +1,361 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_5']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/5/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/5/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/5/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/5/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/5/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp-6.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp-6.conf
@@ -1,0 +1,361 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_6']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/6/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/6/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/6/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/6/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/6/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp-7.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp-7.conf
@@ -1,0 +1,361 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_7']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/7/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/7/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/7/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/7/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/7/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp-8.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp-8.conf
@@ -1,0 +1,361 @@
+<source>
+  @type forward
+  @id input_forward
+  @label @mainstream
+  bind 0.0.0.0
+  port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_8']}"
+</source>
+
+<label @mainstream>
+
+  # Also, sets the tag based on the logging metadata.  If logging type is splunk, then the low/high volume setting is checked, and
+  # the tag becomes a concatenation of the proper Splunk token, the volume setting, and the splunk setting.  Otherwise,
+  # set the value to the log type set in the metadata (e.g., sumologic).  Failing that, set the tag to systemlog.
+  # Example - applog.splunk.low.<token>, applog.sumologic.custom-source.custom-category.<collector-url>
+  <match applog>
+    @type record_reformer
+    @id set_logging_tag_applog
+    enable_ruby true
+    tag ${if not record['ETHOS_LOGGING'].nil?; if record['ETHOS_LOGGING']['type'].to_s == "splunk"; record['ETHOS_LOGGING']['attributes']['volume'] == "low" ? ( "applog.splunk.low"  ) : ( "applog.splunk.high" ); elsif record['ETHOS_LOGGING']['type'].to_s == "sumologic"; "applog.sumologic." + record['ETHOS_LOGGING']['attributes']['source_name'].to_s + "." + record['ETHOS_LOGGING']['attributes']['source_category'].to_s + "." + record['ETHOS_LOGGING']['attributes']['collector_url'].to_s; end; else "systemlog"; end}
+  </match>
+
+  <filter applog.splunk.**>
+    @type record_transformer
+    @id format_for_splunk
+    enable_ruby true
+    renew_record true
+    auto_typecast true
+    <record>
+      timestamp ${record['timestamp']}
+      host ${record['source_host']}
+      index ${record['ETHOS_LOGGING']['attributes']['index']}
+      source ${record['CONTAINER_IMAGE']},${record['CONTAINER_NAME']},${record["CONTAINER_ID"]}
+      sourcetype ${record['ETHOS_LOGGING']['attributes']['source_type']}
+      message ${record['message']}
+    </record>
+  </filter>
+
+  <match systemlog>
+    @type rewrite_tag_filter
+    @id split_kernel_system_logs
+    rewriterule1 _TRANSPORT kernel systemlog.kernel
+    rewriterule2 _TRANSPORT .+ systemlog.systemd
+  </match>
+
+  # Same as the above, only for system logs, using the FLUENTD_SYSTEM_LOG_TYPE environment variable.
+  <match systemlog.systemd>
+    @type record_reformer
+    @id set_logging_tag_systemlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['_SYSTEMD_UNIT']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  <match systemlog.kernel>
+    @type record_reformer
+    @id set_logging_tag_systemlog_kernel
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      source ${record['SYSLOG_IDENTIFIER']}
+      message ${record['MESSAGE'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+    </record>
+  </match>
+
+  # Handle tagging for syslog events, sending them as system logs
+  <match systemlog.syslog.**>
+    @type record_reformer
+    @id set_logging_tag_syslog
+    enable_ruby true
+    tag ${if not ENV['FLUENTD_SYSTEM_LOG_TYPE'].nil?; if ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_SYSTEM_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "systemlog.splunk.low" ) : ( "systemlog.splunk.high" ); elsif ENV['FLUENTD_SYSTEM_LOG_TYPE'].to_s == "sumologic"; "systemlog.sumologic." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_SYSTEM_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+  </match>
+
+  # Handle tagging for Mesos executor logs, sending them as system logs
+  <match executorlog>
+    @type record_reformer
+    @id set_logging_tag_executorlog
+    enable_ruby true
+    auto_typecast true
+    tag ${if not ENV['FLUENTD_MESOS_LOG_TYPE'].nil?; if ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "splunk"; ENV['FLUENTD_MESOS_LOG_SPLUNK_VOLUME'].to_s == "low" ? ( "executorlog.splunk.low"  ) : ( "executorlog.splunk.high" ); elsif ENV['FLUENTD_MESOS_LOG_TYPE'].to_s == "sumologic"; "executorlog.sumologic." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCENAME'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_SOURCECATEGORY'].to_s + "." + ENV['FLUENTD_MESOS_LOG_SUMOLOGIC_COLLECTORURL'].to_s; end; else "logging.disabled"; end}
+    <record>
+      host ${record['source_host']}
+      message ${record['message'].to_s.gsub(/((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})/, "<POSSIBLE_CREDIT_CARD_NUMBER>").gsub(/\s*-e\s+(?<param>\w+)=(?<value>\S+)/, " -e \\k<param>=xxxxx").gsub(/(?<param>[A-Z_]+)\s*->\s*(?<value>\S+)/, "\\k<param> -> xxxxx").gsub(/EnvironmentVariable\((?<param>[A-Z_]+)\s*\,\s*(?<value>\S+)\)/, "EnvironmentVariable\(\\k<param>,xxxxx\)")}
+      source ${record['file_path'].split('/')[10]}
+    </record>
+  </match>
+
+  # Discard logs that don't have a sender configured (splunk, sumologic, etc.)
+  <match logging.disabled>
+    @type null
+  </match>
+
+  <match applog.splunk.high>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/applog.splunk.high/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/8/applog/splunk/high/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/applog.splunk.high/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_high_metrics
+      @label @counts
+      tag fluentd.apploghigh.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match applog.splunk.low>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id applog_to_lvc_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_LVC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_LVC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_LVC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/applog.splunk.low/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index ${record["index"]}
+      source ${record["source"]}
+      sourcetype ${record["sourcetype"]}
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/8/applog/splunk/low/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/applog.splunk.low/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id applog_metrics
+      @label @counts
+      tag fluentd.apploglow.metrics
+      aggregate all
+      count_keys *
+      unit minute
+    </store>
+  </match>
+
+  <match systemlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id systemlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/systemlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_SYSTEM_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/8/systemlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/systemlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id systemlog_metrics
+      @label @counts
+      tag fluentd.systemlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+  <match executorlog.splunk.*>
+    @type copy
+    <store>
+      @type splunk-http-eventcollector
+      @id executorlog_to_splunk
+      server "#{ENV['FLUENTD_SPLUNK_HEC_SERVER']}"
+      verify "#{ENV['FLUENTD_SPLUNK_HEC_SSL_VERIFY']}"
+      token "#{ENV['FLUENTD_SPLUNK_HEC_TOKEN']}"
+      time_key "#{ENV['FLUENTD_SPLUNK_HEC_TIME_KEY']}"
+      all_items "#{ENV['FLUENTD_SPLUNK_HEC_ALL_ITEMS']}"
+      post_retry_max "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_MAX']}"
+      post_retry_interval "#{ENV['FLUENTD_SPLUNK_HEC_POST_RETRY_INTERVAL']}"
+      protocol "#{ENV['FLUENTD_SPLUNK_HEC_PROTOCOL']}"
+      batch_size_limit "#{ENV['FLUENTD_SPLUNK_HEC_BATCH_SIZE_LIMIT']}"
+      coerce_to_utf8 "#{ENV['FLUENTD_SPLUNK_HEC_COERCE_TO_UTF8']}"
+      non_utf8_replacement_string "#{ENV['FLUENTD_SPLUNK_HEC_NON_UTF8_REPLACEMENT_STRING']}"
+
+      buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/executorlog.splunk/"
+      buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_SPLUNK_HEC_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_SPLUNK_HEC_NUM_THREADS']}"
+
+      host ${record["host"]}
+      index "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_INDEX']}"
+      source ${record["source"]}
+      sourcetype "#{ENV['FLUENTD_MESOS_LOG_SPLUNK_SOURCETYPE']}"
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}collector/8/executorlog/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_PATH']}/8/s3/executorlog.splunk/"
+        buffer_queue_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_QUEUE_LIMIT']}"
+        buffer_chunk_limit "#{ENV['FLUENTD_SPLUNK_HEC_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_INTERVAL']}"
+        flush_at_shutdown "#{ENV['FLUENTD_SPLUNK_HEC_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_SPLUNK_HEC_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id executorlog_metrics
+      @label @counts
+      tag fluentd.executorlog.metrics
+      aggregate all
+      count_keys message
+      unit minute
+    </store>
+  </match>
+
+</label>
+
+<label @counts>
+  <match fluentd.*.metrics>
+    @type stdout
+  </match>
+</label>

--- a/docker-fluentd/conf/ethos-fluentd-collector-mp.conf
+++ b/docker-fluentd/conf/ethos-fluentd-collector-mp.conf
@@ -1,0 +1,47 @@
+<source>
+  @type multiprocess
+
+  # optional:
+  #graceful_kill_interval 2s
+  #graceful_kill_interval_increment 3s
+  #graceful_kill_timeout 60s
+
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-mp-1.conf
+    pid_file /var/run/fluentd_child1.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-mp-2.conf
+    sleep_before_start 5s
+    pid_file /var/run/fluentd_child2.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-mp-3.conf
+    sleep_before_shutdown 5s
+    pid_file /var/run/fluentd_child3.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-mp-4.conf
+    sleep_before_shutdown 5s
+    pid_file /var/run/fluentd_child4.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-mp-5.conf
+    pid_file /var/run/fluentd_child5.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-mp-6.conf
+    sleep_before_start 5s
+    pid_file /var/run/fluentd_child6.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-mp-7.conf
+    sleep_before_shutdown 5s
+    pid_file /var/run/fluentd_child7.pid
+  </process>
+  <process>
+    cmdline -c /fluentd/etc/ethos-fluentd-collector-mp-8.conf
+    sleep_before_shutdown 5s
+    pid_file /var/run/fluentd_child8.pid
+  </process>
+</source>

--- a/docker-fluentd/conf/ethos-fluentd-forwarder-mp.conf
+++ b/docker-fluentd/conf/ethos-fluentd-forwarder-mp.conf
@@ -1,0 +1,196 @@
+<source>
+  type monitor_agent
+  bind 0.0.0.0
+  port 24220
+</source>
+
+<source>
+  @type tcp
+  @id input_from_tcp
+  @label @mainstream
+  port 5170
+  format json
+  tag local.tcp
+</source>
+
+<source>
+  @type syslog
+  @id input_from_syslog_tcp
+  @label @mainstream
+  port 5140
+  protocol_type tcp
+  format syslog
+  time_format 1 %Y-%m-%dT%H:%M:%S.%L%z
+  tag local.syslog
+</source>
+
+<source>
+  @type systemd
+  @id ingest_from_journald
+  @label @mainstream
+  path "#{ENV['FLUENTD_SYSTEMD_PATH']}"
+  filters "#{ENV['FLUENTD_SYSTEMD_FILTERS']}"
+  pos_file "#{ENV['FLUENTD_SYSTEMD_POS_FILE']}"
+  read_from_head "#{ENV['FLUENTD_SYSTEMD_READ_FROM_HEAD']}"
+  strip_underscores "#{ENV['FLUENTD_SYSTEMD_STRIP_UNDERSCORES']}"
+  tag local.systemlog
+</source>
+
+<source>
+  @type tail
+  @id ingest_from_tail
+  @label @mainstream
+  read_from_head "#{ENV['FLUENTD_TAIL_READ_FROM_HEAD']}"
+  refresh_interval "#{ENV['FLUENTD_TAIL_REFRESH_INTERVAL']}"
+  enable_watch_timer "#{ENV['FLUENTD_TAIL_ENABLE_WATCH_TIMER']}"
+  rotate_wait "#{ENV['FLUENTD_TAIL_ROTATE_WAIT']}"
+  path "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/**/std*"
+  exclude_path "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/**/std*.*"
+  pos_file "#{ENV['FLUENTD_TAIL_EXECUTOR_LOG_PATH']}/fluentd.pos"
+  path_key "#{ENV['FLUENTD_TAIL_PATH_KEY']}"
+  format none
+  tag local.executorlog
+</source>
+
+<label @mainstream>
+
+  # Drop logs with blank lines
+  <filter local.executorlog>
+    @type grep
+    @id blank_line_filter
+    regexp1 message .+
+  </filter>
+  <filter local.systemlog>
+    @type grep
+    @id blank_line_filter2
+    regexp1 MESSAGE .+
+  </filter>
+
+  # Drop logs coming from the Docker journald driver (we use executor logs instead)
+  <filter local.systemlog>
+    @type grep
+    @id docker_journald_filter
+    exclude1 CONTAINER_NAME .+
+  </filter>
+
+  # Set the timestamp and source_host for all local logs
+  <match local.systemlog>
+    @type record_reformer
+    @id set_host_and_timestamp_field
+    tag ${tag_parts[1]}
+    <record>
+      timestamp ${(Time.now.to_f).to_s}
+      source_host "#{ENV['MESOS_CLUSTER']},#{ENV['ethos_role']},#{ENV['zone']},#{ENV['HOST']}"
+    </record>
+  </match>
+
+  <match local.executorlog>
+    @type record_reformer
+    @id set_record_metadata
+    tag reformed.${tag_parts[1]}
+    <record>
+      timestamp ${(Time.now.to_f).to_s}
+      source_host "#{ENV['MESOS_CLUSTER']},#{ENV['ethos_role']},#{ENV['zone']},#{ENV['HOST']}"
+      CONTAINER_NAME ${"mesos-" + record['file_path'].to_s.split("/")[6] + "." + record['file_path'].to_s.split("/")[12]}
+    </record>
+  </match>
+
+  # Run applog tagged records through the ethos plugin to see if they have the logging metadata in the docker label
+  <filter reformed.executorlog>
+    @type ethos_filter
+    @id get_ethos_metadata
+    merge_json_message "#{ENV['FLUENTD_ETHOSPLUGIN_MERGE_JSON']}"
+    cache_size "#{ENV['FLUENTD_ETHOSPLUGIN_CACHE_SIZE']}"
+    cache_ttl "#{ENV['FLUENTD_ETHOSPLUGIN_CACHE_TTL']}"
+    get_container_id_tag "#{ENV['FLUENTD_ETHOSPLUGIN_GET_TAG_FLAG']}"
+    container_id_attr "#{ENV['FLUENTD_ETHOSPLUGIN_CONTAINER_FIELD']}"
+  </filter>
+
+  # Any records that have the ETHOS_LOGGING attribute are applogs, anything with file_path are executor logs.  Everything else is a system log.
+  <match reformed.executorlog>
+    @type rewrite_tag_filter
+    @id split_app_logs
+    rewriterule1 ETHOS_LOGGING .+ applog
+    rewriterule2 file_path .+ executorlog
+  </match>
+
+  # Discard all executor logs except for those specific to the ETHOS cluster
+  <filter executorlog>
+    @type grep
+    @id filter_mesos_executor_logs
+    regexp1 file_path executors\/(agentfill|apigateway|aqua-agent|aqua-ethos-setup|aqua-gateway|aqua-web|booster|capcom|docker-cleanup|dsn|ecr-login|etcd|ethos-datadog|ethos-fluentd|ethos-splunkforwarder|feature-flipper-cache|flight-director|jenkins|iam-role-iptables|iam-role-proxy|klam-ssh|mercury|moonbeam|moonmaker|orca|prometheus|sidekick|skopos)
+  </filter>
+
+  <match *>
+    @type copy
+    <store>
+      @type forward
+      @id output_to_fluentd_collector
+      expire_dns_cache "{#ENV['FLUENTD_FORWARD_DNS_TTL']}"
+      send_timeout "#{ENV['FLUENTD_FORWARD_SEND_TIMEOUT']}"
+      recover_wait "#{ENV['FLUENTD_FORWARD_RECOVER_WAIT']}"
+      heartbeat_interval "#{ENV['FLUENTD_FORWARD_HEARTBEAT_INTERVAL']}"
+      heartbeat_type "#{ENV['FLUENTD_FORWARD_HEARTBEAT_TYPE']}"
+      phi_failure_detector "#{ENV['FLUENTD_FORWARD_PHI_FAILURE_DETECTOR']}"
+      phi_threshold "#{ENV['FLUENTD_FORWARD_PHI_THRESHOLD']}"
+      hard_timeout "#{ENV['FLUENTD_FORWARD_HARD_TIMEOUT']}"
+      buffer_type "#{ENV['FLUENTD_FORWARD_BUFFER_TYPE']}"
+      buffer_path "#{ENV['FLUENTD_FORWARD_BUFFER_PATH']}/forward/"
+      buffer_queue_limit "#{ENV['FLUENTD_FORWARD_BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['FLUENTD_FORWARD_BUFFER_CHUNK_LIMIT']}"
+      flush_interval "#{ENV['FLUENTD_FORWARD_FLUSH_INTERVAL']}"
+      flush_at_shutdown "#{ENV['FLUENTD_FORWARD_FLUSH_AT_SHUTDOWN']}"
+      retry_wait "#{ENV['FLUENTD_FORWARD_RETRY_WAIT']}"
+      max_retry_wait "#{ENV['FLUENTD_FORWARD_MAX_RETRY_WAIT']}"
+      retry_limit "#{ENV['FLUENTD_FORWARD_RETRY_LIMIT']}"
+      disable_retry_limit "#{ENV['FLUENTD_FORWARD_DISABLE_RETRY_LIMIT']}"
+      num_threads "#{ENV['FLUENTD_FORWARD_NUM_THREADS']}"
+
+      <server>
+        name fluentd_collector_lb
+        host "#{ENV['FLUENTD_COLLECTOR_LB']}"
+        port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_1']}"
+        weight "#{ENV['FLUENTD_COLLECTOR_WEIGHT']}"
+      </server>
+      <server>
+        name fluentd_collector_lb
+        host "#{ENV['FLUENTD_COLLECTOR_LB']}"
+        port "#{ENV['FLUENTD_COLLECTOR_PORT_MP_2']}"
+        weight "#{ENV['FLUENTD_COLLECTOR_WEIGHT']}"
+      </server>
+      <secondary>
+        @type s3
+        s3_bucket "#{ENV['FLUENTD_AWS_S3_BUCKET']}"
+        s3_region us-east-1
+        path "#{ENV['FLUENTD_AWS_S3_BUCKET_PATH']}"
+        s3_object_key_format "%{path}forwarder/#{ENV['HOST']}_%{time_slice}_%{index}.%{file_extension}"
+        store_as text
+        buffer_type "#{ENV['FLUENTD_FORWARD_BUFFER_TYPE']}"
+        buffer_path "#{ENV['FLUENTD_FORWARD_BUFFER_PATH']}/s3/"
+        buffer_queue_limit "#{ENV['FLUENTD_FORWARD_BUFFER_QUEUE_LIMIT']}" 
+        buffer_chunk_limit "#{ENV['FLUENTD_FORWARD_BUFFER_CHUNK_LIMIT']}"
+        flush_interval "#{ENV['FLUENTD_FORWARD_FLUSH_INTERVAL']}" 
+        flush_at_shutdown "#{ENV['FLUENTD_FORWARD_FLUSH_AT_SHUTDOWN']}"
+        retry_limit "#{ENV['FLUENTD_FORWARD_RETRY_LIMIT']}"
+        <assume_role_credentials>
+         role_arn "#{ENV['FLUENTD_AWS_IAM_ROLE']}"
+         role_session_name fluentd-s3
+        </assume_role_credentials>
+      </secondary>
+    </store>
+    <store>
+      @type flowcounter
+      @id forwarder_metrics
+      @label @counts
+      aggregate tag
+      count_keys timestamp
+      unit minute
+    </store>
+  </match>
+</label>
+
+<label @counts>
+  <match **>
+    @type stdout
+  </match>
+</label>


### PR DESCRIPTION
Fluentd configurations that support secondary aws s3 endpoints for fail-safe logging.  We need a repository that we can share configurations for fluentd instead of pre-packaging configurations.  Since configurations have no sensitive data they should be fine here.

Closed PR:
https://git.corp.adobe.com/adobe-platform/docker-fluentd/pull/2