### PR TITLE
KLAM: adding new suffix group names

### DIFF
--- a/klam-ssh/v2/setup_klam.sh
+++ b/klam-ssh/v2/setup_klam.sh
@@ -247,7 +247,7 @@ HostbasedAuthentication no
 LogLevel INFO
 PermitUserEnvironment no
 DenyUsers root
-AllowGroups core ADOBE_PLATFORM_$(echo "${ROLE_NAME}" | awk -F "-" '{print toupper($5)}')_ROLE_ADMIN $(echo $IAM_GROUP_NAME |awk '{ print $0 }') ADOBE_PLATFORM_$(echo "${ROLE_NAME}" | awk -F "-" '{print toupper($5)}')_POWER_USER
+AllowGroups core ADOBE_PLATFORM_$(echo "${ROLE_NAME}" | awk -F "-" '{print toupper($5)}')_ROLE_ADMIN $(echo $IAM_GROUP_NAME |awk '{ print $0 }') ADOBE_PLATFORM_$(echo "${ROLE_NAME}" | awk -F "-" '{print toupper($5)}')_POWER_USER ADOBE_PLATFORM_AWS_$(echo "${ROLE_NAME}" | awk -F     "-" '{print toupper($5)}')_POWER_USER ADOBE_PLATFORM_AWS_$(echo "${ROLE_NAME}" | awk -F "-" '{print toupper($5)}')_ROLE_ADMIN
 EOT
 mv -f sshd_config /etc/ssh/sshd_config
 chmod 600 /etc/ssh/sshd_config


### PR DESCRIPTION
1. ADOBE_PLATFORM_AWS group names were changed.  this broke power-user group only access users.